### PR TITLE
Move default values into array node definition

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -98,10 +98,10 @@ class Configuration implements ConfigurationInterface
         $node = $builder->root('features');
 
         $node
-            ->treatTrueLike(['enabled' => true])
-            ->treatFalseLike(['enabled' => false])
-            ->treatNullLike(['enabled' => null])
             ->prototype('array')
+                ->treatTrueLike(['enabled' => true])
+                ->treatFalseLike(['enabled' => false])
+                ->treatNullLike(['enabled' => null])
                 ->beforeNormalization()
                     ->ifTrue(function ($v) { return is_double($v); })
                     ->then(function ($v) { return ['enabled' => true, 'ratio' => $v]; })


### PR DESCRIPTION
Ran into an issue where notices were being raised when the value of a feature was set to "null". This was  due to the ```ConfigProvider``` always expecting an ```enabled``` property. As far as I can tell, unless the intent was to have:

```
features: false
```

that we should be doing the defaults within the array node definition, which will apply it to each ```feature```:

```
features:
   one: null
   two: true
```